### PR TITLE
Allow non-ASCII description

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,11 @@ The configuration example above changes the default configuration to show all pr
         <td><code>55</code></td>
     </tr>
     <tr>
+        <td><code>ascii_description</code></td>
+        <td>If <code>True</code>, all non-ASCII characters in the project description will be removed. Useful for filtering out distractive emoji, but hurtful in non-English cases. (Note: GitHub emoji commands (e.g. <code>:smile:</code>) are always removed.)</td>
+        <td><code>True</code></td>
+    </tr>
+    <tr>
         <td><code>projects_history_folder</code></td>
         <td>The folder used for storing history files (<code>csv</code> files with project metadata). If <code>null</code>, no history files will be created.</td>
         <td><code>./history</code></td>

--- a/src/best_of/default_config.py
+++ b/src/best_of/default_config.py
@@ -64,6 +64,9 @@ def prepare_configuration(cfg: dict) -> Dict:
     if "min_description_length" not in config:
         config.min_description_length = MIN_PROJECT_DESC_LENGTH
 
+    if "ascii_description" not in config:
+        config.ascii_description = True
+
     if "hide_project_license" not in config:
         config.hide_project_license = False
 

--- a/src/best_of/generators/markdown_list.py
+++ b/src/best_of/generators/markdown_list.py
@@ -292,7 +292,11 @@ def generate_project_md(
             )
         )
     )
-    description = utils.process_description(project.description, desc_length)
+    description = utils.process_description(
+        project.description,
+        desc_length,
+        ascii_only=configuration.ascii_description,
+    )
 
     # target="_blank"
     if project.resource:

--- a/src/best_of/projects_collection.py
+++ b/src/best_of/projects_collection.py
@@ -680,7 +680,7 @@ def collect_projects_info(
         if project_info.description:
             # Process description
             project_info.description = utils.process_description(
-                project_info.description, 120
+                project_info.description, 120, ascii_only=config.ascii_description
             )
 
         # Check and update the project category

--- a/src/best_of/utils.py
+++ b/src/best_of/utils.py
@@ -33,14 +33,16 @@ def remove_special_chars(text: str) -> str:
     return text.encode("ascii", "ignore").decode("ascii")
 
 
-def process_description(text: str, max_lenght: int) -> str:
+def process_description(text: str, max_length: int, *, ascii_only: bool) -> str:
     if not text:
         return ""
 
     # Remove github emoji commands
     text = re.sub(":[a-zA-Z_]*:", "", text).strip()
 
-    text = remove_special_chars(text).strip()
+    if ascii_only:
+        text = remove_special_chars(text)
+    text = text.strip()
     text = text.replace('"', "")
     text = text.replace("'", "")
     text = text.replace("<", "")
@@ -53,7 +55,7 @@ def process_description(text: str, max_lenght: int) -> str:
         # make sure that the text always ends with a dot
         text += "."
 
-    return clean_whitespaces(textwrap.shorten(text, width=max_lenght, placeholder=".."))
+    return clean_whitespaces(textwrap.shorten(text, width=max_length, placeholder=".."))
 
 
 url_validator = re.compile(


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [x] New Feature
- [ ] Feature Improvment
- [ ] Refactoring
- [x] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->

Add config `ascii_description` to resolves #61.

<table>
    <thead>
        <tr>
            <th>Config</th>
            <th>Description</th>
            <th>Default</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><code>ascii_description</code></td>
            <td>If <code>True</code>, all non-ASCII characters in the project description will be removed. Useful for
                filtering out distractive emoji, but hurtful in non-English cases. (Note: GitHub emoji commands (e.g.
                <code>:smile:</code>) are always removed.)</td>
            <td><code>True</code></td>
        </tr>
    </tbody>
</table>

Technically:
- I add a keyword argument `ascii_only: bool` to `utils.process_description`.
- Pass `config.ascii_description` to it when calling.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of-generator/blob/main/CONTRIBUTING.md) document.

  Sorry I can't use docker, therefore I can't run tests on my own. May I depend on the CI?

- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
