### PR TITLE
Clarify `conda_id` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Every project can also be expanded to show additional project information (by cl
     </tr>
     <tr>
         <td><code>conda_id</code></td>
-        <td>Project ID on the <a href="https://anaconda.org">conda package manager</a>. If the main package is provided on a different channel, prefix the ID with the given channel: e.g. <code>conda-forge/tensorflow</code></td>
+        <td>Project ID on the <a href="https://www.conda.io/">conda package manager</a>. If the string is without any `/`, it is interpreted as package name in the [`anaconda` channel](https://anaconda.org/anaconda/). Otherwise, prefix the ID with the given channel: e.g. <code>conda-forge/tensorflow</code></td>
     </tr>
     <tr>
         <td><code>npm_id</code></td>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] New Feature
- [ ] Feature Improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other, please describe:

**Description:**

While reading the `conda_id` documentation, I was a bit confused, especially by the "If the main package is provided on a different channel" string, as it was not clear to me what "different channel" meant. By looking into the code, I understood that the "default" channel is the `anaconda` one, and if you are referring to another channel, you need to indicate it, so I tried to clarify the docs (I am not sure I was able to do that).

More in general, I think that pointing users to the `anaconda` channel by default is a bit risky as that channel is not free to use (see https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/), but this is another story.

I also changed the link for the conda package manager to point to the home page of the open source conda project, and not to the anaconda company, that are two different entities (even if historically related).

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of-generator/blob/main/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
