### PR TITLE
fix: Corrected the reference to `committedDate` in GitHub

### DIFF
--- a/src/best_of/integrations/github_integration.py
+++ b/src/best_of/integrations/github_integration.py
@@ -323,7 +323,7 @@ def update_via_github_api(project_info: Dict) -> None:
             except Exception as ex:
                 log.warning(
                     "Failed to parse timestamp: "
-                    + str(github_info.target.committedDate),
+                    + str(github_info.masterCommit.target.committedDate),
                     exc_info=ex,
                 )
         if (


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->

In the following code, it is obvious that the `github_info.target.committedDate` in the warning should be `github_info.masterCommit.target.committedDate`.

```python
if github_info.masterCommit.target.committedDate:
    try:
        last_commit_pushed_at = parse(
            str(github_info.masterCommit.target.committedDate), ignoretz=True
        )
        ...
    except Exception as ex:
        log.warning(
            "Failed to parse timestamp: "
            + str(github_info.target.committedDate),
            exc_info=ex,
        )
```

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of-generator/blob/main/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
