### PR TITLE
Fix GitLab `lastActivityAt` support

### DIFF
--- a/src/best_of/integrations/gitlab_integration.py
+++ b/src/best_of/integrations/gitlab_integration.py
@@ -133,7 +133,7 @@ class GitLabIntegration(BaseIntegration):
                     f"Failed to parse timestamp: {repo_info.createdAt}", exc_info=ex
                 )
 
-        if repo_info.lastActivity:
+        if repo_info.lastActivityAt:
             try:
                 last_activity_at = parse(repo_info.lastActivityAt, ignoretz=True)
                 if (


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->

Correct `repo_info.lastActivity` to `repo_info.lastActivityAt` (add `-At`).
The latter is consistent with the GraphQL query and other python codes.

This bug has never been discovered because there are too few GitLab-only projects. If there are other data sources providing `updated_at`, then the wrong data from GitLab will be overwritten.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of-generator/blob/main/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
